### PR TITLE
Allow building with GHC 8.6

### DIFF
--- a/generic-data.cabal
+++ b/generic-data.cabal
@@ -34,6 +34,7 @@ library
     Generic.Data.Internal.Surgery
     Generic.Data.Internal.Utils
   build-depends:
+    base-orphans >= 0.8,
     contravariant,
     first-class-families,
     show-combinators,

--- a/orphans/Generic/Data/Orphans.hs
+++ b/orphans/Generic/Data/Orphans.hs
@@ -8,44 +8,9 @@
 module Generic.Data.Orphans where
 
 import Data.Functor.Classes
+import Data.Orphans ()
 import Data.Semigroup
 import GHC.Generics
-
-instance Monoid c => Applicative (K1 i c) where
-  pure _ = K1 mempty
-  K1 a <*> K1 b = K1 (mempty a b)
-
-instance Semigroup (V1 p) where
-  v <> _ = v
-
-instance Semigroup (U1 p) where
-  _ <> _ = U1
-
-instance Monoid (U1 p) where
-  mempty = U1
-  mappend = (<>)
-
-deriving instance Semigroup c => Semigroup (K1 i c p)
-deriving instance Monoid c => Monoid (K1 i c p)
-
-deriving instance Semigroup (f p) => Semigroup (M1 i c f p)
-deriving instance Monoid (f p) => Monoid (M1 i c f p)
-
-instance (Semigroup (f p), Semigroup (g p)) => Semigroup ((f :*: g) p) where
-  (x1 :*: y1) <> (x2 :*: y2) = (x1 <> x2) :*: (y1 <> y2)
-
-instance (Monoid (f p), Monoid (g p)) => Monoid ((f :*: g) p) where
-  mempty = mempty :*: mempty
-  mappend (x1 :*: y1) (x2 :*: y2) = mappend x1 x2 :*: mappend y1 y2
-
-deriving instance Semigroup p => Semigroup (Par1 p)
-deriving instance Monoid p => Monoid (Par1 p)
-
-deriving instance Semigroup (f p) => Semigroup (Rec1 f p)
-deriving instance Monoid (f p) => Monoid (Rec1 f p)
-
-deriving instance Semigroup (f (g p)) => Semigroup ((f :.: g) p)
-deriving instance Monoid (f (g p)) => Monoid ((f :.: g) p)
 
 instance Eq1 V1 where
   liftEq _ v _ = case v of {}

--- a/test/unit.hs
+++ b/test/unit.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -41,6 +42,13 @@ pl1 = p1
 
 data E = E0 | E1 | E2
   deriving (Eq, Show, Generic)
+
+maybeModuleName :: String
+#if MIN_VERSION_base(4,12,0)
+maybeModuleName = "GHC.Maybe"
+#else
+maybeModuleName = "GHC.Base"
+#endif
 
 main :: IO ()
 main = defaultMain test
@@ -100,7 +108,7 @@ test = testGroup "unit"
 
   , testGroup "Meta"
       [ testCase "datatypeName" $ "Maybe" @?= gdatatypeName @(Maybe Int)
-      , testCase "moduleName" $ "GHC.Base" @?= gmoduleName @(Maybe Int)
+      , testCase "moduleName" $ maybeModuleName @?= gmoduleName @(Maybe Int)
       , testCase "packageName" $ "base" @?= gpackageName @(Maybe Int)
       , testCase "isNewtype" $ False @?= gisNewtype @(Maybe Int)
       , testCase "conName" $ "Just" @?= gconName (Just ())


### PR DESCRIPTION
Two things need to be tweaked in order to allow `generic-data` to be built with `base-4.12` (which is shipped with GHC 8.6):

* Several of the instances defined in `Generic.Data.Orphans` are now defined directly in `base`, so the orphans now conflict with those. I work around this issue by depending on the `base-orphans` package, which specifically backports those instances.
* `Maybe` is now defined in `GHC.Maybe` instead of `GHC.Base` in `base-4.12`, so work around this with some CPP in the unit tests.