### PR TITLE
Generically's Monoid instance uses wrapped type's (<>)

### DIFF
--- a/src/Generic/Data/Internal/Generically.hs
+++ b/src/Generic/Data/Internal/Generically.hs
@@ -36,9 +36,10 @@ instance (Generic a, GShow0 (Rep a)) => Show (Generically a) where
 instance (Generic a, Semigroup (Rep a ())) => Semigroup (Generically a) where
   (<>) = gmappend
 
-instance (Generic a, Monoid (Rep a ())) => Monoid (Generically a) where
+instance (Semigroup a, Generic a, Monoid (Rep a ())) => Monoid (Generically a) where
   mempty = gmempty
-  mappend = gmappend'
+  -- Use `a`'s semigroup so implementation is consistent with custom `Semigroup` instances
+  mappend (Generically x) (Generically y) = Generically (x <> y)
 
 instance (Generic a, GEnum StandardEnum (Rep a)) => Enum (Generically a) where
   toEnum = gtoEnum

--- a/test/unit.hs
+++ b/test/unit.hs
@@ -16,6 +16,9 @@ import Generic.Data.Orphans ()
 data P a = P a a
   deriving (Generic, Generic1)
 
+instance Semigroup a => Semigroup (P a) where
+  x <> y = unGenerically (Generically x <> Generically y)
+
 type PTy a = a -> a -> Generically (P a)
 
 p :: PTy a


### PR DESCRIPTION
PR for https://github.com/Lysxia/generic-data/issues/17

Note that `Generically` now **does not** have a `Monoid` instance unless it wraps something with a `Semigroup` instance, so had to add an instance derivation in the test too.