### PR TITLE
Add generic Ix

### DIFF
--- a/src/Generic/Data.hs
+++ b/src/Generic/Data.hs
@@ -61,6 +61,14 @@ module Generic.Data
   , gmaxBound
   , GBounded()
 
+    -- ** 'Ix'
+    -- | Can also be derived by GHC as part of the standard.
+  , grange
+  , gindex
+  , ginRange
+  , GIx()
+  , gunsafeIndex
+
     -- * Higher-kinded classes
 
     -- ** 'Functor'

--- a/src/Generic/Data/Internal/Generically.hs
+++ b/src/Generic/Data/Internal/Generically.hs
@@ -18,6 +18,7 @@ module Generic.Data.Internal.Generically where
 import Control.Applicative
 import Data.Functor.Classes
 import Data.Semigroup
+import Data.Ix
 import GHC.Generics
 
 import Generic.Data.Internal.Prelude
@@ -69,6 +70,11 @@ instance (Generic a, GEnum StandardEnum (Rep a)) => Enum (Generically a) where
   enumFromThen = genumFromThen
   enumFromTo = genumFromTo
   enumFromThenTo = genumFromThenTo
+
+instance (Generic a, Ord (Rep a ()), GIx (Rep a)) => Ix (Generically a) where
+  range = grange
+  index = gindex
+  inRange = ginRange
 
 instance (Generic a, GBounded (Rep a)) => Bounded (Generically a) where
   minBound = gminBound


### PR DESCRIPTION
I assume Ix should be added because it is in base too.

I am unsure whether it is better to avoid importing `unsafeIndex` from `GHC.Arr`.

I also fixed the mixup of expected and actual values in the unit tests.