### PR TITLE
Use EmptyCase to define absurd1

### DIFF
--- a/src/Generic/Data/Internal/Utils.hs
+++ b/src/Generic/Data/Internal/Utils.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
     BangPatterns,
+    EmptyCase,
     FlexibleContexts,
     PolyKinds #-}
 
@@ -40,7 +41,7 @@ coerce1 = coerce
 
 -- | Elimination of @V1@.
 absurd1 :: V1 x -> a
-absurd1 !_ = error "impossible"
+absurd1 x = case x of {}
 
 -- | A helper for better type inference.
 from' :: Generic a => a -> Rep a ()


### PR DESCRIPTION
Currently, `absurd1` is defined like this:

```hs
absurd1 :: V1 x -> a
absurd1 !_ = error "impossible"
```

The right-hand side of this function (`error "impossible"`) can never be reached. This is harmless now, but on GHC 8.10.1 this will actually give a warning:

```
[10 of 17] Compiling Generic.Data.Internal.Utils ( src/Generic/Data/Internal/Utils.hs, interpreted )

src/Generic/Data/Internal/Utils.hs:43:1: warning: [-Woverlapping-patterns]
    Pattern match has inaccessible right hand side
    In an equation for ‘absurd1’: absurd1 !_ = ...
   |
43 | absurd1 !_ = error "impossible"
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Thankfully, there is a backwards-compatible way to avoid the warning: just define `absurd1` with `EmptyCase` instead. This patch does just that.