### PR TITLE
Add parentheses and backticks to constructor/selector output where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# next
+
+- Fix a bug where `gshowsPrec` would incorrectly display prefix uses of
+  symbol data constructors or record selectors (e.g., `data R = (:!:) Int Int`
+  or `data S = MkS { (##) :: Int -> Int }`).
+- Fix a bug where `gshowsPrec` would incorrectly display infix uses of
+  alphanumeric data constructors (e.g., ```data T = Int `MkT` Int```).
+
 # 0.8.1.0
 
 - Add `Old` type family mapping newtypes to their underlying type.

--- a/generic-data.cabal
+++ b/generic-data.cabal
@@ -40,6 +40,7 @@ library
   build-depends:
     base-orphans >= 0.8,
     contravariant,
+    ghc-boot-th,
     show-combinators,
     base >= 4.9 && < 5
   hs-source-dirs:      orphans
@@ -55,6 +56,7 @@ test-suite unit-test
     tasty,
     tasty-hunit,
     generic-data,
+    show-combinators >= 0.2,
     base
   ghc-options: -Wall
   default-language: Haskell2010

--- a/test/unit.hs
+++ b/test/unit.hs
@@ -65,7 +65,7 @@ e1 = allEs !! 1
 eLast = last allEs
 
 allEs :: [FiniteE]
-allEs = 
+allEs =
     [ SE0 False False
     , SE0 False  True
     , SE0  True False
@@ -83,6 +83,20 @@ instance (Functor f, Show1 f, Show1 g) => Show1 (MyCompose f g) where
 
 instance (Functor f, Show1 f, Show1 g, Show a) => Show (MyCompose f g a) where
   showsPrec = showsPrec1
+
+-- Regression tests for T30
+data T30a = MkT30a { (##) :: () }
+  deriving Generic
+
+data T30b = (:!:) () ()
+          | () `MkT30b` ()
+  deriving Generic
+
+instance Show T30a where
+  showsPrec = gshowsPrec
+
+instance Show T30b where
+  showsPrec = gshowsPrec
 
 maybeModuleName :: String
 #if MIN_VERSION_base(4,12,0)
@@ -157,7 +171,7 @@ test = testGroup "unit"
         ]
       ]
   , testGroup "Ix"
-      [ testGroup "only nullary constructors" 
+      [ testGroup "only nullary constructors"
         [ testCase "range" $ [E0, E1, E2] @=? grange (E0, E2)
         , testCase "index" $ 1 @=? gindex (E1, E3) E2
         , testCase "inRange (within)" $ True @=? ginRange (E1, E3) E2
@@ -175,6 +189,11 @@ test = testGroup "unit"
   , testGroup "Show"
       [ testCase "show" $ "P 1 2" @=? show (p' 1 2)
       , testCase "showsPrec" $ "(P 1 2)" @=? showsPrec 11 (p' 1 2) ""
+      , testGroup "T30"
+        [ testCase "MkT30a" $ "(MkT30a {(##) = ()})" @=? showsPrec 11 (MkT30a {(##) = ()}) ""
+        , testCase "(:!:)" $ "(:!:) () ()" @=? show ((:!:) () ())
+        , testCase "MkT30b" $ "() `MkT30b` ()" @=? show (() `MkT30b` ())
+        ]
       ]
 
   , testGroup "Show1"


### PR DESCRIPTION
This addresses parts (1) and (2) of https://github.com/Lysxia/generic-data/issues/30#issuecomment-602216159. Fixes #30 for good.