### PR TITLE
Use `FiniteEnum` for `Generically` instance

### DIFF
--- a/src/Generic/Data/Internal/Generically.hs
+++ b/src/Generic/Data/Internal/Generically.hs
@@ -112,13 +112,13 @@ instance (Generic a, GRead0 (Rep a)) => Read (Generically a) where
 instance (Generic a, GShow0 (Rep a)) => Show (Generically a) where
   showsPrec = gshowsPrec
 
-instance (Generic a, GEnum StandardEnum (Rep a)) => Enum (Generically a) where
-  toEnum = gtoEnum
-  fromEnum = gfromEnum
-  enumFrom = genumFrom
-  enumFromThen = genumFromThen
-  enumFromTo = genumFromTo
-  enumFromThenTo = genumFromThenTo
+instance (Generic a, GEnum FiniteEnum (Rep a)) => Enum (Generically a) where
+  toEnum = gtoFiniteEnum
+  fromEnum = gfromFiniteEnum
+  enumFrom = gfiniteEnumFrom
+  enumFromThen = gfiniteEnumFromThen
+  enumFromTo = gfiniteEnumFromTo
+  enumFromThenTo = gfiniteEnumFromThenTo
 
 instance (Generic a, Ord (Rep a ()), GIx (Rep a)) => Ix (Generically a) where
   range = grange


### PR DESCRIPTION
This makes it possible to use `deriving via Generically T instance Enum T` for many more types `T`.

In the process of opening this PR, I have realised why one _might_ not want to make this change, namely because of the restrictions outlined in the docs:

> The Enum instances of the field types need to start enumerating from 0. In particular, Int is an unfit field type, because the enumeration of the negative values starts before 0.

This one could fairly easily be lifted by doing a bit of extra arithmetic with `minBound` and `maxBound` to shift things to zero, though in some cases that would exacerbate the second restriction...

> There can only be up to maxBound :: Int values (because the implementation represents the cardinality explicitly as an Int ). This restriction makes Word an invalid field type as well. Notably, it is insufficient for each individual field types to stay below this limit. Instead it applies to the generic type as a whole.

This unfortunately is a bit problematic, and I don't think there's enough information available at the type level for us to produce a custom compile-time error. On the other hand, one could perhaps make the argument that users are unlikely to want to use these sorts of types, or that the restriction is pretty obvious given the use of `Int`, and that `Enum` is not the safest abstraction anyway.

I also haven't looked in to backwards compatibility, i.e. whether `FiniteEnum` strictly generalises `StandardEnum` by assigning the same indices.